### PR TITLE
NOISSUE - Fix the current thing url

### DIFF
--- a/lib/things.py
+++ b/lib/things.py
@@ -11,7 +11,7 @@ class Things:
     def create(self, thing, token):
         '''Creates thing entity in the database'''
         mf_resp = response.Response()
-        http_resp = requests.post(self.url + "/things", json=thing, headers={"Authorization": token})
+        http_resp = requests.post(self.url + "/things/bulk", json=thing, headers={"Authorization": token})
         if http_resp.status_code != 201:
             mf_resp.error.status = 1
             mf_resp.error.message = errors.handle_error(errors.things["create"], http_resp.status_code)

--- a/tests/test_things.py
+++ b/tests/test_things.py
@@ -15,14 +15,14 @@ params = None
 
 
 def test_create_thing(requests_mock):
-    requests_mock.register_uri("POST", url + "/things", headers={"location": "/things/" + thing_id}, status_code=201)
+    requests_mock.register_uri("POST", url + "/things/bulk", headers={"location": "/things/" + thing_id}, status_code=201)
     r = s.things.create(thing, token)
     assert r.error.status == 0
     assert thing_id == r.value
 
 
 def test_create_existing_thing(requests_mock):
-    requests_mock.register_uri("POST", url + "/things", headers={"location": "/things/" + thing_id}, status_code=409)
+    requests_mock.register_uri("POST", url + "/things/bulk", headers={"location": "/things/" + thing_id}, status_code=409)
     r = s.things.create(thing, token)
     assert r.error.status == 1
     assert r.error.message == "Entity already exist."


### PR DESCRIPTION
Signed-off-by: 0x6f736f646f <blackd0t@protonmail.com>

### What does this do?
It fixes the current thing URL

### Which issue(s) does this PR fix/relate to?
It doesn't relate to previous issues

### List any changes that modify/break current functionality
The previous thing URL was `/things` yet from the docs, the thing URL should be `/things/bulk` as indicated [here](https://docs.mainflux.io/api/#create-thing)

### Have you included tests for your changes?
Yes. Added the new things url

### Did you document any new/modified functionality?
No
