### PR TITLE
NOISSUE - Fix create things response

### DIFF
--- a/lib/things.py
+++ b/lib/things.py
@@ -11,7 +11,7 @@ class Things:
     def create(self, thing, token):
         '''Creates thing entity in the database'''
         mf_resp = response.Response()
-        http_resp = requests.post(self.url + "/things", json=thing, headers={"Authorization": token})
+        http_resp = requests.post(self.url + "/things/bulk", json=thing, headers={"Authorization": token})
         if http_resp.status_code != 201:
             mf_resp.error.status = 1
             mf_resp.error.message = errors.handle_error(errors.things["create"], http_resp.status_code)

--- a/lib/things.py
+++ b/lib/things.py
@@ -16,8 +16,7 @@ class Things:
             mf_resp.error.status = 1
             mf_resp.error.message = errors.handle_error(errors.things["create"], http_resp.status_code)
         else:
-            location = http_resp.headers.get("location")
-            mf_resp.value = location.split('/')[2]
+            mf_resp.value = http_resp.json()
         return mf_resp
 
     def create_bulk(self, things, token):


### PR DESCRIPTION
Signed-off-by: 0x6f736f646f <blackd0t@protonmail.com>

### What does this do?
It fixes the create things response function

### Which issue(s) does this PR fix/relate to?
It doesn't relate to previous issues

### List any changes that modify/break current functionality
Create things API response is a json object 
```json
{"things":[{"id":"64140f0b-6448-41cf-967e-1bbcc703c332","name":"thing_name","key":"659aa6ca-1781-4a69-9a20-689ddb235506"}]}
```
which we can be able to display. The original implementation was location value in the header which is currently not there

### Have you included tests for your changes?
Yes.

### Did you document any new/modified functionality?
No
