### PR TITLE
NOISSUE - Add Share User Group with Things Group

### DIFF
--- a/lib/groups.py
+++ b/lib/groups.py
@@ -98,3 +98,12 @@ class Groups:
             mf_resp.error.status = 1
             mf_resp.error.message = errors.handle_error(errors.groups["delete"], http_resp.status_code)
         return mf_resp
+
+    def share_groups(self, token, user_group_id, thing_group_id):
+        '''Adds access rights on thing groups to the user group'''
+        mf_resp = response.Response()
+        http_resp = requests.post(self.url + "/groups/" + user_group_id + "/share", headers={"Authorization": token}, json=thing_group_id)
+        if http_resp.status_code != 200:
+            mf_resp.error.status = 1
+            mf_resp.error.message = errors.handle_error(errors.groups["assign"], http_resp.status_code)
+        return mf_resp

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -9,6 +9,7 @@ members = {"members": channel_id, "type": "channels"}
 group = {"group_name": "group"}
 group_id = "888-888-888"
 group_id1 = "989-787-686"
+thing_group_id = "868-464-262"
 token = "9a8b7c6d5e4f3g21"
 url = "http://localhost"
 
@@ -118,3 +119,9 @@ def test_delete_group_does_not_exist(requests_mock):
     r = s.groups.delete(group_id, token)
     assert r.error.status == 1
     assert r.error.message == "Group does not exist."
+
+def test_share_groups(requests_mock):
+    requests_mock.register_uri("POST", url + "/groups/" + group_id + "/share", status_code=200,
+                               headers={"Authorization": token}, json={"thing_group_id": thing_group_id})
+    r = s.groups.share_groups(token, group_id, thing_group_id)
+    assert r.error.status == 0


### PR DESCRIPTION
Signed-off-by: 0x6f736f646f <blackd0t@protonmail.com>

### What does this do?
It add share user group with things group

### Which issue(s) does this PR fix/relate to?
It doesn't relate to previous issues

### List any changes that modify/break current functionality
There was no check access by key previously

### Have you included tests for your changes?
Yes.

### Did you document any new/modified functionality?
No
