### PR TITLE
MF-16 - Removed pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,0 @@
-[build-system]
-requires = [
-    "setuptools>=54",
-    "wheel"
-]
-build-backend = "setuptools.build_meta"
-


### PR DESCRIPTION
Signed-off-by: 0x6f736f646f <blackd0t@protonmail.com>

### What does this do?
It removes `pyproject.toml`

### Which issue(s) does this PR fix/relate to?
#16 

### List any changes that modify/break current functionality
There was a `pyproject.toml` previously

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
No
